### PR TITLE
Improve project overview in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MNIST Visualizer
 
-This is just an updated version of my original: https://github.com/csenn/nn-visualizer from 2016
+This application visualizes how a feed‑forward neural network classifies handwritten digits from the MNIST dataset. You can examine the network’s weights, biases and activations and step through saved epochs to see how the connections change over time. A “flashlight” mode lets you feed an image through the network and watch which paths become active.
 
-The updates are minimal, just removed the requirements for a server, use vite instead of webpack, updated libraries, and some small tweaks.
+The project was originally created in **2019** as a learning tool and has since been updated to use Vite instead of Webpack along with newer dependencies. It is not meant to achieve state‑of‑the‑art accuracy—it simply demonstrates how data flows through a neural network in an accessible way.
+
+This repository is based on the earlier [csenn/nn-visualizer](https://github.com/csenn/nn-visualizer) project from 2016 and removes the need for a server.


### PR DESCRIPTION
## Summary
- clarify purpose of MNIST Visualizer
- mention educational intent and that it shows data flowing through the network
- note that the app was originally built in 2019 and modernized

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845a124b5cc832cb270ccebb5897a94